### PR TITLE
No null X509 certificate in Saml2Setting

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -950,7 +950,10 @@ public class SettingsBuilder {
 			if (propValue == null)
 				break;
 
-			list.add(loadCertificateFromProp(propValue));
+			X509Certificate cert = loadCertificateFromProp(propValue);
+
+			if (cert != null)
+				list.add(cert);
 		}
 
 		return list;


### PR DESCRIPTION
`Saml2Sttings#checkIdpx509certRequired` don't return false even when all IPD X509 certificates in `idpx509certMulti` are null, because the list contains a null value.