### PR TITLE
Extract the context classes (AuthnContextClassRef) from the response

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -73,6 +73,11 @@ public class SamlResponse {
 	private Map<String,String> nameIdData = null;
 
 	/**
+	 * Context class (AuthnContextClassRef) in the response
+	 */
+	private String contextClass = null;
+
+	/**
 	 * URL of the current host + current view
 	 */
 	private String currentUrl;
@@ -88,7 +93,7 @@ public class SamlResponse {
 	private Exception validationException;
 
 	/**
-	 * The respone status code and messages
+	 * The response status code and messages
 	 */
 	private SamlResponseStatus responseStatus;
 
@@ -574,6 +579,18 @@ public class SamlResponse {
 			spNameQualifier = nameIdData.get("SPNameQualifier");
 		}
 		return spNameQualifier;
+	}
+
+	public String getContextClass() throws XPathExpressionException, ValidationError {
+		if (this.contextClass == null) {
+			NodeList nodes = this.queryAssertion("/saml:AuthnStatement/saml:AuthnContext/saml:AuthnContextClassRef");
+			switch(nodes.getLength()) {
+				case 0: break;	// None defined. There should be one, but no big deal if an IDP fails to provide it
+				case 1: this.contextClass = nodes.item(0).getTextContent(); break;
+				default: throw new ValidationError("Multiple AuthnContextClassRef found in the Assertion.", ValidationError.WRONG_NUMBER_OF_CONTEXT_CLASSES);
+			}
+		}
+		return this.contextClass;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/exception/ValidationError.java
+++ b/core/src/main/java/com/onelogin/saml2/exception/ValidationError.java
@@ -54,6 +54,7 @@ public class ValidationError extends SAMLException {
 	public static final int KEY_ALGORITHM_ERROR = 47;
 	public static final int MISSING_ENCRYPTED_ELEMENT = 48;
 	public static final int INVALID_ISSUE_INSTANT_FORMAT = 49;
+	public static final int WRONG_NUMBER_OF_CONTEXT_CLASSES = 50;
 
 	private int errorCode;
 

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -92,6 +92,11 @@ public class Auth {
 	private String nameidSPNameQualifier;
 
 	/**
+	 * AuthnContextClassRef - extracted from the AuthnStatement of the SAML Response
+	 */
+	private String contextClass;
+
+	/**
 	 * SessionIndex. When the user is logged, this stored it from the AuthnStatement of the SAML Response
 	 */
 	private String sessionIndex;
@@ -1209,6 +1214,7 @@ public class Auth {
 				nameidFormat = samlResponse.getNameIdFormat();
 				nameidNameQualifier = samlResponse.getNameIdNameQualifier();
 				nameidSPNameQualifier = samlResponse.getNameIdSPNameQualifier();
+				contextClass = samlResponse.getContextClass();
 				authenticated = true;
 				attributes = samlResponse.getAttributes();
 				sessionIndex = samlResponse.getSessionIndex();
@@ -1441,6 +1447,11 @@ public class Auth {
 	public final String getNameIdSPNameQualifier() {
 		return nameidSPNameQualifier;
 	}
+
+	/**
+	 * @return the context class (AuthnContextClassRef) of the assertion
+	 */
+	public String getContextClass() { return contextClass; }
 
 	/**
 	 * @return the SessionIndex of the assertion

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -528,9 +528,11 @@ public class AuthTest {
 		Auth auth = new Auth(settings, request, response);
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getErrors().isEmpty());
+		assertNull(auth.getContextClass());
 		auth.processResponse();
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getAttributes().isEmpty());
+		assertNull(auth.getContextClass());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
 		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
@@ -564,6 +566,7 @@ public class AuthTest {
 		assertEquals(attrValues, auth2.getAttribute("uid"));
 		assertEquals(attrValues2, auth2.getAttribute("mail"));
 		assertEquals(attrValues3, auth2.getAttribute("eduPersonAffiliation"));
+		assertEquals("urn:oasis:names:tc:SAML:2.0:ac:classes:Password", auth2.getContextClass());
 		assertEquals(keys, auth2.getAttributesName());
 	}
 


### PR DESCRIPTION
We have a use case that means we need to reject SAML logins that didn't have the right authentication mode from the IDP, but with some application logic rather than just rejecting the assertion.

This seems like potentially useful downstream information for library users anyway.